### PR TITLE
[38기 김우진]ADD: Skeleton 기능구현

### DIFF
--- a/src/pages/Main/List/ListMain.js
+++ b/src/pages/Main/List/ListMain.js
@@ -1,12 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { MainContext } from '../MainText';
 import ListCard from './ListCard';
+import Skeleton from './Skeleton';
 
 const ListMain = () => {
   const [houseList, setHouseList] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    setLoading(true);
     fetch('./data/ListMock.json')
       .then(data => data.json())
       .then(data => {
@@ -15,12 +18,18 @@ const ListMain = () => {
       });
   }, []);
 
-  if (loading) return;
-
+  if (loading)
+    return (
+      <S.CardWrapper>
+        <Skeleton width="316px" height="400px" number={20} />{' '}
+      </S.CardWrapper>
+    );
   return (
     <S.CardWrapper>
-      {houseList?.map(data => (
-        <ListCard key={data.id} data={data} />
+      {houseList.map(data => (
+        <S.CardStandard>
+          <ListCard key={data.id} data={data} />
+        </S.CardStandard>
       ))}
     </S.CardWrapper>
   );
@@ -33,12 +42,13 @@ const S = {
     display: flex;
     padding: 0 40px;
     width: 100%;
-    justify-content: space-evenly;
     flex-wrap: wrap;
     background-color: #eeeeee;
   `,
 
   CardStandard: styled.div`
     margin: 0px 20px;
+    display: flex;
+    flex-direction: row;
   `,
 };

--- a/src/pages/Main/List/Skeleton.js
+++ b/src/pages/Main/List/Skeleton.js
@@ -1,0 +1,65 @@
+import styled, { keyframes } from 'styled-components';
+
+const Skeleton = ({ width, height, number }) => {
+  return number
+    ? [...Array(number)].map((skeleton, idx) => {
+        return (
+          <StyledSkeleton width={width} height={height} key={idx}>
+            <ImageBox />
+            <TextBox />
+            <TextBox />
+            <TextBox />
+          </StyledSkeleton>
+        );
+      })
+    : null;
+};
+
+export default Skeleton;
+
+const loading = keyframes`
+from {
+  left: -200px;
+}
+to {
+  left: 100%;
+}
+`;
+
+const StyledSkeleton = styled.div`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  box-shadow: 1px 1px 20px rgba(0, 0, 0, 0.2);
+  border-radius: 15px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  margin: 20px 22px 20px 22px;
+
+  ::before {
+    content: '';
+    display: block;
+    position: absolute;
+    left: -200px;
+    top: 0;
+    height: 100%;
+    width: 200px;
+    background: linear-gradient(to right, red 0%, blue 50% red 100%);
+    animation: ${loading} 1000ms ease-in-out infinite;
+  }
+`;
+
+const ImageBox = styled.div`
+  width: 315px;
+  height: 295px;
+  background-color: white;
+  border-radius: 15px;
+`;
+
+const TextBox = styled.div`
+  width: 200px;
+  height: 15px;
+  margin: 10px 0 0 5px;
+  background-color: white;
+`;

--- a/src/pages/Main/MainText.js
+++ b/src/pages/Main/MainText.js
@@ -1,0 +1,53 @@
+import React, { createContext, useState } from 'react';
+
+export const MainContext = createContext();
+// createContext()로 비어 있는 context가 만들어진다.
+
+function MainStore(props) {
+  // props로 지정하고 싶은 상태를 만들어준다.
+
+  const [countbed, setCountbed] = useState(0);
+  const [countbedroom, setCountbedroom] = useState(0);
+  const [countbathroom, setCountbathroom] = useState(0);
+  const [buildingType, setBuildingType] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [filterFetcher, setFilterFetcher] = useState([]);
+  const [filterValue, setFilterValue] = useState();
+  const [valueFilterMain, setValueFilterMain] = useState('');
+  const [valueTheme, setValueTheme] = useState('');
+  const [houseList, setHouseList] = useState([]);
+
+  return (
+    //value를 통해 전달하고 싶은 값을 넣어준다.
+    <MainContext.Provider
+      value={{
+        countbed,
+        setCountbed,
+        countbedroom,
+        setCountbedroom,
+        countbathroom,
+        setCountbathroom,
+        buildingType,
+        setBuildingType,
+        minPrice,
+        setMinPrice,
+        maxPrice,
+        setMaxPrice,
+        filterFetcher,
+        setFilterFetcher,
+        filterValue,
+        setFilterValue,
+        valueFilterMain,
+        setValueFilterMain,
+        valueTheme,
+        setValueTheme,
+        houseList,
+        setHouseList,
+      }}
+    >
+      {props.children}
+    </MainContext.Provider>
+  );
+}
+export default MainStore;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 리스티 이미지 로딩간 스켈레톤 표시 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 스켈레톤 UI
- Fetch간 Settimeout 으로 로딩 걸어서 진행
- useState을 통한 로딩 시 상태구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 로딩간 스켈레톤의 존재여부가 소비자의 경험에 미치는 영향에대해 생각해 볼 수 있게 되었습니다. 
- 로딩 상태부여에 대해 알게 되었습니다. 

<br />

## :: 기타 질문 및 특이 사항
- 원래 fetch 로 객체의 갯수를 가져와 객체의 수 만큼 스켈레톤의 갯수를 구현하려 하였으나 어차피 로딩전에는 fetch로 객체의 갯수를 불러오지 못하는데 혹시 객체의 갯수를 맞춰서 화면에 띄울 수 있는것인지 궁금합니다.                                                                                                  
